### PR TITLE
[CF]: Standardize Error Handling

### DIFF
--- a/distill/src/errors.rs
+++ b/distill/src/errors.rs
@@ -10,7 +10,7 @@ pub struct Exit;
 impl Exit {
     pub fn with_message<T>(message: &str) -> T {
         println!("{}️ {}", ERR_PREFIX, message);
-        exit(1)
+        exit(1);
     }  
 }
 

--- a/distill/src/errors.rs
+++ b/distill/src/errors.rs
@@ -1,0 +1,23 @@
+
+use std::process::exit;
+use std::io::{ErrorKind, Error as IOError};
+
+
+const ERR_PREFIX: &str = "❗️";
+
+pub struct Exit;
+
+impl Exit {
+    pub fn with_message<T>(message: &str) -> T {
+        println!("{}️ {}", ERR_PREFIX, message);
+        exit(1)
+    }  
+}
+
+
+pub fn describe_rc_file_open_error(err: IOError, filename: &str) -> String {
+    match err.kind() {
+        ErrorKind::NotFound => format!("Cannot find RC file: `{}`", filename),
+        _any_other_kind => format!("Failed to open `{}`.", filename),
+    }
+}

--- a/distill/src/init.rs
+++ b/distill/src/init.rs
@@ -23,13 +23,11 @@ const RC_FILE_SRC: &str = r#"{
 }
 "#;
 
-const TOKENS_FILE_SRC: &str = r###"{
-  "colors": {
-    "blue": "#264b96",
-    "green": "#006f3c",
-    "red": "#bf212f"
-  }
-}
+const TOKENS_FILE_SRC: &str = r###"
+colors:
+    blue: "#264b96"
+    green: "#006f3c"
+    red: "#bf212f"
 "###;
 
 const EXAMPLE_TEMPLATE_SRC: &str = r###"# Background Colors
@@ -37,28 +35,33 @@ bg-[$colors.key]:
   background-colors: var(--$colors.key)
 "###;
 
-pub fn initialize_moonshinerc(path: &str) {
-    if Path::new(path).exists() {
+pub fn initialize_moonshinerc(path: &Path) {
+    let path_string = match path.to_str() {
+        None => Exit::with_message("Failed to read RC filepath as a string"),
+        Some(path_string) => path_string,
+    };
+
+    if path.exists() {
         Exit::with_message(
-            &format!("RC File already exists: `{}`.", path)
+            &format!("RC File already exists: `{}`.", path_string)
         )
     }
 
     println!("Initializing `.moonshinerc`");
 
-    fs::write(path, RC_FILE_SRC).unwrap_or(
+    fs::write(path, RC_FILE_SRC).unwrap_or_else(|_err| {
         Exit::with_message(
-            &format!("Failed to write file: {}.", path)
+            &format!("Failed to write file: {}.", path_string)
         )
-    );
+    });
 
-    fs::write("./design-tokens.yml", TOKENS_FILE_SRC).unwrap_or(
+    fs::write("./design-tokens.yml", TOKENS_FILE_SRC).unwrap_or_else(|_err| {
         Exit::with_message("Unable to write design-tokens.yml to current directory")
-    );
+    });
 
-    write_file_creating_dirs("./templates/example.yml", EXAMPLE_TEMPLATE_SRC).unwrap_or(
+    write_file_creating_dirs("./templates/example.yml", EXAMPLE_TEMPLATE_SRC).unwrap_or_else(|_err| {
         Exit::with_message("Unable to write to ./templates/example.yml")
-    );
+    });
 
     println!("\x1b[32mDone\x1b[0m - now run 'distill' to start using Moonshine CSS");
 }

--- a/distill/src/init.rs
+++ b/distill/src/init.rs
@@ -1,10 +1,9 @@
 use super::io;
-use super::ErrorHandler;
+use super::{Exit};
 
 use io::write_file_creating_dirs;
 use std::fs;
 use std::path::Path;
-use std::process::exit;
 
 const RC_FILE_SRC: &str = r#"{
   "options": {
@@ -40,18 +39,26 @@ bg-[$colors.key]:
 
 pub fn initialize_moonshinerc(path: &str) {
     if Path::new(path).exists() {
-        exit(ErrorHandler::rc_file_collision(path));
+        Exit::with_message(
+            &format!("RC File already exists: `{}`.", path)
+        )
     }
 
-    println!("Initializing .moonshinerc");
+    println!("Initializing `.moonshinerc`");
 
-    fs::write(path, RC_FILE_SRC).expect("Unable to write .moonshinerc to current directory");
+    fs::write(path, RC_FILE_SRC).unwrap_or(
+        Exit::with_message(
+            &format!("Failed to write file: {}.", path)
+        )
+    );
 
-    fs::write("./design-tokens.yml", TOKENS_FILE_SRC)
-        .expect("Unable to write design-tokens.yml to current directory");
+    fs::write("./design-tokens.yml", TOKENS_FILE_SRC).unwrap_or(
+        Exit::with_message("Unable to write design-tokens.yml to current directory")
+    );
 
-    write_file_creating_dirs("./templates/example.yml", EXAMPLE_TEMPLATE_SRC)
-        .expect("️❗ Unable to write to ./templates/example.yml");
+    write_file_creating_dirs("./templates/example.yml", EXAMPLE_TEMPLATE_SRC).unwrap_or(
+        Exit::with_message("Unable to write to ./templates/example.yml")
+    );
 
     println!("\x1b[32mDone\x1b[0m - now run 'distill' to start using Moonshine CSS");
 }

--- a/distill/src/init.rs
+++ b/distill/src/init.rs
@@ -40,7 +40,7 @@ bg-[$colors.key]:
 
 pub fn initialize_moonshinerc(path: &str) {
     if Path::new(path).exists() {
-        exit(ErrorHandler::rc_file_overwrite(path));
+        exit(ErrorHandler::rc_file_collision(path));
     }
 
     println!("Initializing .moonshinerc");

--- a/distill/src/init.rs
+++ b/distill/src/init.rs
@@ -38,7 +38,7 @@ bg-[$colors.key]:
 
 pub fn initialize_moonshinerc(path: &str) {
     if Path::new(path).exists() {
-        println!("File \"{}\" already exists", path);
+        println!("❗️ File \"{}\" already exists", path);
         return;
     }
 
@@ -50,7 +50,7 @@ pub fn initialize_moonshinerc(path: &str) {
         .expect("Unable to write design-tokens.yml to current directory");
 
     write_file_creating_dirs("./templates/example.yml", EXAMPLE_TEMPLATE_SRC)
-        .expect("Unable to write to ./templates/example.yml");
+        .expect("️❗ Unable to write to ./templates/example.yml");
 
     println!("\x1b[32mDone\x1b[0m - now run 'distill' to start using Moonshine CSS");
 }

--- a/distill/src/init.rs
+++ b/distill/src/init.rs
@@ -1,8 +1,10 @@
 use super::io;
+use super::ErrorHandler;
 
 use io::write_file_creating_dirs;
 use std::fs;
 use std::path::Path;
+use std::process::exit;
 
 const RC_FILE_SRC: &str = r#"{
   "options": {
@@ -38,8 +40,7 @@ bg-[$colors.key]:
 
 pub fn initialize_moonshinerc(path: &str) {
     if Path::new(path).exists() {
-        println!("❗️ File \"{}\" already exists", path);
-        return;
+        exit(ErrorHandler::rc_file_overwrite(path));
     }
 
     println!("Initializing .moonshinerc");

--- a/distill/src/init.rs
+++ b/distill/src/init.rs
@@ -1,5 +1,5 @@
 use super::io;
-use super::{Exit};
+use super::errors::Exit;
 
 use io::write_file_creating_dirs;
 use std::fs;

--- a/distill/src/main.rs
+++ b/distill/src/main.rs
@@ -89,6 +89,10 @@ impl ErrorHandler {
         println!("{} Failed parse RC File as JSON: {}.", ERR_PREFIX, err);
         1
     }
+    pub fn rc_file_overwrite(path_to_rc_file: &str) -> i32 {
+        println!("{} RC File already exists: `{}`.", ERR_PREFIX, path_to_rc_file);
+        1
+    }
 }
 
 

--- a/distill/src/main.rs
+++ b/distill/src/main.rs
@@ -64,10 +64,8 @@ pub struct RCFile {
 impl RCFile {
     pub fn load_from_json(path: &Path) -> Self {
         let rc_file_handle = fs::File::open(&path).unwrap_or_else(|err| {
-            Exit::with_message(&errors::describe_rc_file_open_error(
-                err,
-                DEFAULT_RC_FILE_NAME,
-            ))
+            let message = &errors::describe_rc_file_open_error(err, DEFAULT_RC_FILE_NAME);
+            Exit::with_message(message)
         });
 
         json::from_reader(BufReader::new(rc_file_handle)).unwrap_or_else(|err| {

--- a/distill/src/main.rs
+++ b/distill/src/main.rs
@@ -89,7 +89,7 @@ impl ErrorHandler {
         println!("{} Failed parse RC File as JSON: {}.", ERR_PREFIX, err);
         1
     }
-    pub fn rc_file_overwrite(path_to_rc_file: &str) -> i32 {
+    pub fn rc_file_collision(path_to_rc_file: &str) -> i32 {
         println!("{} RC File already exists: `{}`.", ERR_PREFIX, path_to_rc_file);
         1
     }

--- a/distill/src/main.rs
+++ b/distill/src/main.rs
@@ -17,6 +17,10 @@ use std::time::Instant;
 use template_syntax::{transformations_from_templates, transformations_from_tokens, CSSTemplate, Options};
 use transformation_syntax::{Intermediate, TokenGroups};
 
+
+const DEFAULT_RC_FILE_NAME: &str = ".moonshinerc";
+const ERR_PREFIX: &str = "❗️";
+
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
@@ -72,17 +76,17 @@ impl RCFile {
 
 
 /// Prints diagnostic messages and returns appropriate OS error codes
-struct ErrorHandler;
+pub struct ErrorHandler;
 impl ErrorHandler {
-    fn rc_file_open(err: IOError) -> i32 {
+    pub fn rc_file_open(err: IOError) -> i32 {
         match err.kind() {
-            ErrorKind::NotFound => println!("❗️ Failed to open `{}`. File does not exist.", ".moonshinerc"),
-            _other_kind => println!("❗️ Failed to open `{}`.", ".moonshinerc"),
+            ErrorKind::NotFound => println!("{}️ Failed to open `{}`. File does not exist.", ERR_PREFIX, DEFAULT_RC_FILE_NAME),
+            _other_kind => println!("{} Failed to open `{}`.", ERR_PREFIX, DEFAULT_RC_FILE_NAME),
         };
         1
     }
-    fn rc_file_parse(err: json::Error) -> i32 {
-        println!("❗ Failed parse RC File as JSON: {}.", err);
+    pub fn rc_file_parse(err: json::Error) -> i32 {
+        println!("{} Failed parse RC File as JSON: {}.", ERR_PREFIX, err);
         1
     }
 }
@@ -97,7 +101,7 @@ fn main() {
     let path_to_rc_file = args
         .config
         .as_deref()
-        .unwrap_or(Path::new("./.moonshinerc"));
+        .unwrap_or(Path::new(DEFAULT_RC_FILE_NAME));
 
     if args.init != 0 {
         initialize_moonshinerc(&path_to_rc_file.to_str().unwrap());

--- a/distill/src/main.rs
+++ b/distill/src/main.rs
@@ -59,28 +59,32 @@ pub struct RCFile {
 impl RCFile {
     pub fn load_from_json(path: &str) -> Self {
         let rc_file_handle = match fs::File::open(&path) {
-            Err(err) => exit(handle_rc_file_open_error(err)),
+            Err(err) => exit(ErrorHandler::rc_file_open(err)),
             Ok(handle) => handle,
         };
 
         match json::from_reader(BufReader::new(rc_file_handle)) {
-            Err(err) => exit(handle_rc_file_parse_error(err)),
+            Err(err) => exit(ErrorHandler::rc_file_parse(err)),
             Ok(deserialized) => deserialized,
         }
     }
 }
 
-/// Print diagnostic messages and return the appropriate OS error code
-fn handle_rc_file_open_error(err: IOError) -> i32 {
-    match err.kind() {
-        ErrorKind::NotFound => println!("❗️ Failed to open `{}`. File does not exist.", ".moonshinerc"),
-        _other_kind => println!("❗️ Failed to open `{}`.", ".moonshinerc"),
-    };
-    1
-}
-fn handle_rc_file_parse_error(err: json::Error) -> i32 {
-    println!("❗ Failed parse RC File as JSON: {}.", err);
-    1
+
+/// Prints diagnostic messages and returns appropriate OS error codes
+struct ErrorHandler;
+impl ErrorHandler {
+    fn rc_file_open(err: IOError) -> i32 {
+        match err.kind() {
+            ErrorKind::NotFound => println!("❗️ Failed to open `{}`. File does not exist.", ".moonshinerc"),
+            _other_kind => println!("❗️ Failed to open `{}`.", ".moonshinerc"),
+        };
+        1
+    }
+    fn rc_file_parse(err: json::Error) -> i32 {
+        println!("❗ Failed parse RC File as JSON: {}.", err);
+        1
+    }
 }
 
 


### PR DESCRIPTION
## Changes
- Introduces the `errors` module
- Replaces `unwrap()` and `expect()` calls with human-friendly error messages.
- Remove duplicate type conversion

## Validation
- Check out this branch
- Run `cargo run -- --init`
- Run `cargo run`
- Verify that no unexpected errors occur